### PR TITLE
Cleanup Issues found by Muse

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/endpoint/EndpointUtils.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/endpoint/EndpointUtils.java
@@ -280,7 +280,6 @@ public class EndpointUtils {
             Set<String> ec2UrlsForZone = DnsResolver.getCNamesFromTxtRecord(dnsName);
             for (String ec2Url : ec2UrlsForZone) {
                 logger.debug("The eureka url for the dns name {} is {}", dnsName, ec2Url);
-                ec2UrlsForZone.add(ec2Url);
             }
             if (DiscoveryUrlType.CNAME.equals(type)) {
                 return ec2UrlsForZone;

--- a/eureka-client/src/main/java/com/netflix/discovery/util/StringCache.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/util/StringCache.java
@@ -32,8 +32,8 @@ public class StringCache {
     public String cachedValueOf(final String str) {
         if (str != null && (lengthLimit < 0 || str.length() <= lengthLimit)) {
             // Return value from cache if available
+            lock.readLock().lock();
             try {
-                lock.readLock().lock();
                 WeakReference<String> ref = cache.get(str);
                 if (ref != null) {
                     return ref.get();
@@ -43,8 +43,8 @@ public class StringCache {
             }
 
             // Update cache with new content
+            lock.writeLock().lock();
             try {
-                lock.writeLock().lock();
                 WeakReference<String> ref = cache.get(str);
                 if (ref != null) {
                     return ref.get();
@@ -59,8 +59,8 @@ public class StringCache {
     }
 
     public int size() {
+        lock.readLock().lock();
         try {
-            lock.readLock().lock();
             return cache.size();
         } finally {
             lock.readLock().unlock();

--- a/eureka-core/src/main/java/com/netflix/eureka/aws/Route53Binder.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/aws/Route53Binder.java
@@ -147,7 +147,9 @@ public class Route53Binder implements AwsBinder {
             Thread.sleep(1000);
             // check change not overwritten
             ResourceRecordSet resourceRecordSet = getResourceRecordSet(rrs.getResourceRecordSet().getName(), rrs.getHostedZone());
-            return resourceRecordSet.getResourceRecords().equals(rrs.getResourceRecordSet().getResourceRecords());
+            if (resourceRecordSet != null) {
+                return resourceRecordSet.getResourceRecords().equals(rrs.getResourceRecordSet().getResourceRecords());
+            }
         }
         return false;
     }

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -191,8 +191,8 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
      * @see com.netflix.eureka.lease.LeaseManager#register(java.lang.Object, int, boolean)
      */
     public void register(InstanceInfo registrant, int leaseDuration, boolean isReplication) {
+        read.lock();
         try {
-            read.lock();
             Map<String, Lease<InstanceInfo>> gMap = registry.get(registrant.getAppName());
             REGISTER.increment(isReplication);
             if (gMap == null) {
@@ -295,8 +295,8 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
      * in the remote peers as valid cancellations, so self preservation mode would not kick-in.
      */
     protected boolean internalCancel(String appName, String id, boolean isReplication) {
+        read.lock();
         try {
-            read.lock();
             CANCEL.increment(isReplication);
             Map<String, Lease<InstanceInfo>> gMap = registry.get(appName);
             Lease<InstanceInfo> leaseToCancel = null;
@@ -462,8 +462,8 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
     public boolean statusUpdate(String appName, String id,
                                 InstanceStatus newStatus, String lastDirtyTimestamp,
                                 boolean isReplication) {
+        read.lock();
         try {
-            read.lock();
             STATUS_UPDATE.increment(isReplication);
             Map<String, Lease<InstanceInfo>> gMap = registry.get(appName);
             Lease<InstanceInfo> lease = null;
@@ -528,8 +528,8 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                                         InstanceStatus newStatus,
                                         String lastDirtyTimestamp,
                                         boolean isReplication) {
+        read.lock();
         try {
-            read.lock();
             STATUS_OVERRIDE_DELETE.increment(isReplication);
             Map<String, Lease<InstanceInfo>> gMap = registry.get(appName);
             Lease<InstanceInfo> lease = null;
@@ -874,8 +874,8 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
         Applications apps = new Applications();
         apps.setVersion(responseCache.getVersionDelta().get());
         Map<String, Application> applicationInstancesMap = new HashMap<String, Application>();
+        write.lock();
         try {
-            write.lock();
             Iterator<RecentlyChangedItem> iter = this.recentlyChangedQueue.iterator();
             logger.debug("The number of elements in the delta queue is : {}",
                     this.recentlyChangedQueue.size());
@@ -954,8 +954,8 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
         Applications apps = new Applications();
         apps.setVersion(responseCache.getVersionDeltaWithRegions().get());
         Map<String, Application> applicationInstancesMap = new HashMap<String, Application>();
+        write.lock();
         try {
-            write.lock();
             Iterator<RecentlyChangedItem> iter = this.recentlyChangedQueue.iterator();
             logger.debug("The number of elements in the delta queue is :{}", this.recentlyChangedQueue.size());
             while (iter.hasNext()) {

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
@@ -20,6 +20,7 @@ import javax.ws.rs.core.MediaType;
 import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -477,7 +478,7 @@ public class RemoteRegionRegistry implements LookupService<String> {
 
     @Override
     public List<InstanceInfo> getInstancesById(String id) {
-        List<InstanceInfo> list = Collections.emptyList();
+        List<InstanceInfo> list = new ArrayList<>(1);
 
         for (Application app : applications.get().getRegisteredApplications()) {
             InstanceInfo info = app.getByInstanceId(id);
@@ -486,7 +487,7 @@ public class RemoteRegionRegistry implements LookupService<String> {
                 return list;
             }
         }
-        return list;
+        return Collections.emptyList();
     }
 
     public Applications getApplicationDeltas() {


### PR DESCRIPTION
This PR cleans up some issues found by a new static analysis platform we just released called Muse. We’ve been using Eureka as a test case after being pointed to it by someone at Netflix and wanted to contribute fixes for some of the issues it found.
This PR addresses these bug types among others:

-  https://errorprone.info/bugpattern/LockNotBeforeTry

-  https://errorprone.info/bugpattern/ModifyCollectionInEnhancedForLoop

-  https://fbinfer.com/docs/next/all-issue-types/#null_dereference